### PR TITLE
Sync to upstream SVF: LLVM 21.1.0, drop deadsnakes PPA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGETPLATFORM
 RUN set -e
 
 # Define LLVM version.
-ENV llvm_version=18.1.0
+ENV llvm_version=21.1.0
 
 # Define home directory
 ENV HOME=/home/SVF-tools
@@ -20,14 +20,13 @@ ENV build_deps="wget xz-utils git tcl software-properties-common gdb"
 RUN apt-get update --fix-missing
 RUN apt-get install -y $build_deps $lib_deps
 
-# Add deadsnakes PPA for multiple Python versions 
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN set -ex; \
-    apt-get update && apt-get install -y python3.10-dev python3-pip \
-            && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1;
-RUN python3 -m pip install pysvf -i https://test.pypi.org/simple/
-RUN python3 -m pip install z3-solver
+# Use the python3 that ships with the Ubuntu 24.04 base image (python 3.12).
+# Avoid pulling python3.10 from ppa:deadsnakes/ppa — Launchpad's PPA infrastructure
+# has been intermittently unreachable from CI runners (HTTP 504 / 2-minute timeouts
+# from add-apt-repository), and SVF does not pin a Python version.
+RUN apt-get install -y python3-dev python3-pip
+RUN python3 -m pip install --break-system-packages pysvf -i https://test.pypi.org/simple/
+RUN python3 -m pip install --break-system-packages z3-solver
 
 
 # Fetch and build SVF source.

--- a/env.sh
+++ b/env.sh
@@ -2,7 +2,7 @@
 
 PROJECTHOME=$(pwd)
 sysOS=`uname -s`
-MajorLLVMVer=18
+MajorLLVMVer=21
 LLVMVer=${MajorLLVMVer}.1.0
 
 LLVMHome="llvm-${LLVMVer}.obj"


### PR DESCRIPTION
Match the upstream SVF/build.sh pin (MajorLLVMVer=21) and remove the ppa:deadsnakes/ppa python3.10 install path. Launchpad's PPA infrastructure has been intermittently unreachable from CI runners (HTTP 504 from add-apt-repository), and SVF does not pin a Python version, so the Ubuntu base-image python3 (24.04 = 3.12) is sufficient.